### PR TITLE
Update blockstream css example

### DIFF
--- a/Theme.md
+++ b/Theme.md
@@ -136,7 +136,7 @@ html {
 }
 
 .invoice {
-  background-color: #15181c;
+  background-color: #343f4c;
 }
 
 .expired__body {


### PR DESCRIPTION
Increase the blockstream css example background invoice - area behind the QR code. Fixes failed scanning.

Fix for issue  285 "Blockstream dark theme causes QR code scanning failure"